### PR TITLE
ci: Specify NuGet source server for snupkg upload

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,4 +26,4 @@ jobs:
             *.nupkg
             *.snupkg
       - name: Push Release to NuGet
-        run: nuget push -NonInteractive ArborSdk.${{ github.ref_name }}.nupkg
+        run: nuget push -NonInteractive ArborSdk.${{ github.ref_name }}.nupkg -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This allows nuget to publish the debugging sources alongside the main package, and also resolves the issue with the `Source parameter was not specified.` error that was occurring on tagging the new release.