### PR TITLE
MIS-49456: Fix escaping quotes in entity creation

### DIFF
--- a/src/Arbor/Api/Gateway/RestGateway.cs
+++ b/src/Arbor/Api/Gateway/RestGateway.cs
@@ -56,7 +56,7 @@ namespace Arbor.Api.Gateway
             hResource.Add(resourceRoot, arrayRepresentation);
             hBody.Add("request", hResource);
 
-            string body = JsonConvert.SerializeObject(hBody, Formatting.None);
+            string body = JsonConvert.SerializeObject(hBody, Formatting.None, new ArborJsonConverter());
 
             //Console.WriteLine(hBody.ToString());
             //Console.WriteLine(body);


### PR DESCRIPTION
## Bug Summary
Request bodies formed via the .NET SDK are escaping characters, causing request validation (API side) to block valid partner requests.

For example, attempting to create an `EmailAddress` entity with the `emailAddressType` set to `"WORK"` (an enum) is returning an unprocessable entity response (422) due to the request actually containing the value `"\"WORK\""`.

## JIRA Ticket

See [MIS-49456](https://orchard.atlassian.net/browse/MIS-49456) for more information

## Solution
Use the available `ArborJsonConverter` as the converter for the serialization of the request body in the `create` method. This custom converter has the functionality to strip escaped quotes and is already in use for the `update` method.

## Checklist

- [ ] Commit messages have been properly prefixed with `fix: ` to ensure correct versioning and rebased with `rebase -i` if needed
- [ ] Tests have been added to avoid regressions where possible
