### PR TITLE
DOPS-18304 Bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,15 +9,15 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 6.0.x
       - name: Package SDK
         run: nuget pack src/ArborSdk.csproj -Build -Symbols -SymbolPackageFormat snupkg
       - name: Upload SDK Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdk
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with: 
           dotnet-version: 6.0.x
       - name: Lint Code Style

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 6.0.x
       - name: Configure NuGet
@@ -19,7 +19,7 @@ jobs:
       - name: Package SDK
         run: nuget pack src/ArborSdk.csproj -Build -Symbols -SymbolPackageFormat snupkg -Version ${{ github.ref_name }}
       - name: Upload SDK Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdk
           path: |


### PR DESCRIPTION
## Summary of changes
https://orchard.atlassian.net/browse/DOPS-18304

Bumps all deprecated GitHub Actions to Node.js 24-compatible versions.

| Action | From | To | Runtime change |
|---|---|---|---|
| `actions/checkout` | `@v3` (node16) | `@v6` (node24) | node16 -> node24 |
| `actions/setup-dotnet` | `@v3` (node16) | `@v5` (node24) | node16 -> node24 |
| `actions/upload-artifact` | `@v4` (node20) | `@v7` (node24) | node20 -> node24 |

### Breaking changes
None. All are drop-in replacements with identical inputs/outputs.